### PR TITLE
Add contingency CancelToken

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,6 +31,6 @@
     "@mathieudutour/js-fatigue": "^1.0.2"
   },
   "dependencies": {
-    "axios": "^0.13.1"
+    "axios": "^0.17.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "redux-object-to-promise",
-  "version": "0.3.3",
+  "version": "0.3.4",
   "description": "Redux middleware to transform an object into a promise",
   "main": "build/index.js",
   "jsnext:main": "src/index.js",

--- a/src/index.js
+++ b/src/index.js
@@ -43,11 +43,13 @@ export default ({
     const CancelToken = axios.CancelToken
     const source = CancelToken.source()
 
-    setTimeout(() => {
-      if (!finished) {
-        source.cancel('Timeout of ' + timeout + 'ms exceeded.')
-      }
-    }, timeout)
+    if (timeout > 0) {
+      setTimeout(() => {
+        if (!finished) {
+          source.cancel('Timeout of ' + timeout + 'ms exceeded.')
+        }
+      }, timeout)
+    }
 
     promise = promise.then(() => axios({
       ...restOfAxiosOptions,
@@ -70,8 +72,12 @@ export default ({
         }
       }, ...transformResponse],
       ...rest
-    }).then(() => {
+    }).then(res => {
       finished = true
+      return res
+    }).catch(err => {
+      finished = true
+      throw err
     }))
 
     const actionToDispatch = {


### PR DESCRIPTION
Hey mate, how you've been doing?

Made this PR because recently I've been having some issues with timeouts on android (RN 0.50.x).
If you make a request to a non-responding server (like a random ip or something):
- on iOS throws an exception immediately (good)
- on Android is hangs forever, not even respecting the timeout specified

So I made a contingency CancelToken that will cancel the request if the timeout has passed, outside `axios` itself. Note that I had to upgrade axios for this.

[Here's a relevant thread, if you're interested](https://github.com/axios/axios/issues/647#issuecomment-322209906)

See ya :)